### PR TITLE
ast: added a PostgreSQL system function

### DIFF
--- a/ast/functions.go
+++ b/ast/functions.go
@@ -351,6 +351,7 @@ const (
 	PgFuncGetUserById          = "pg_get_userbyid"
 	PgFuncObjDescription       = "obj_description"
 	PgFuncShobjDescription     = "shobj_description"
+	PgFuncExtraFloatDigits   = "extra_float_digits"
 )
 
 // FuncCallExpr is for function expression.


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Add a PostgreSQL system function called "extra_float_digits"

### What is changed and how it works?

It is now compatible with the extra_float_digits function at the SQL syntax level
