### PR TITLE
parser.y, unit tests: added support for session characteristic keyword

### DIFF
--- a/consistent_test.go
+++ b/consistent_test.go
@@ -76,7 +76,7 @@ func (s *testConsistentSuite) TestKeywordConsistent(c *C) {
 	tidbKeywordsCollectionDef := extractKeywordsFromCollectionDef(s.content, "\nTiDBKeyword:")
 	c.Assert(s.tidbKeywords, DeepEquals, tidbKeywordsCollectionDef)
 
-	tidb4pgKeywordsCollectionDef := extractKeywordsFromCollectionDef(s.content, "\nTiDB4PGKeyword::")
+	tidb4pgKeywordsCollectionDef := extractKeywordsFromCollectionDef(s.content, "\nTiDB4PGKeyword:")
 	c.Assert(s.tidb4pgKeywords, DeepEquals, tidb4pgKeywordsCollectionDef)
 }
 

--- a/consistent_test.go
+++ b/consistent_test.go
@@ -33,6 +33,7 @@ type testConsistentSuite struct {
 	unreservedKeywords []string
 	notKeywordTokens   []string
 	tidbKeywords       []string
+	tidb4pgKeywords    []string
 }
 
 func (s *testConsistentSuite) SetUpSuite(c *C) {
@@ -48,12 +49,14 @@ func (s *testConsistentSuite) SetUpSuite(c *C) {
 	unreservedKeywordStartMarker := "\t/* The following tokens belong to UnReservedKeyword. Notice: make sure these tokens are contained in UnReservedKeyword. */"
 	notKeywordTokenStartMarker := "\t/* The following tokens belong to NotKeywordToken. Notice: make sure these tokens are contained in NotKeywordToken. */"
 	tidbKeywordStartMarker := "\t/* The following tokens belong to TiDBKeyword. Notice: make sure these tokens are contained in TiDBKeyword. */"
+	tidb4pgKeywordStartMarker := "\t/* The following tokens are added for TiDB for Postgres. */"
 	identTokenEndMarker := "%token\t<item>"
 
 	s.reservedKeywords = extractKeywords(s.content, reservedKeywordStartMarker, unreservedKeywordStartMarker)
 	s.unreservedKeywords = extractKeywords(s.content, unreservedKeywordStartMarker, notKeywordTokenStartMarker)
 	s.notKeywordTokens = extractKeywords(s.content, notKeywordTokenStartMarker, tidbKeywordStartMarker)
-	s.tidbKeywords = extractKeywords(s.content, tidbKeywordStartMarker, identTokenEndMarker)
+	s.tidbKeywords = extractKeywords(s.content, tidbKeywordStartMarker, tidb4pgKeywordStartMarker)
+	s.tidb4pgKeywords = extractKeywords(s.content, tidb4pgKeywordStartMarker, identTokenEndMarker)
 }
 
 func (s *testConsistentSuite) TestKeywordConsistent(c *C) {
@@ -61,7 +64,7 @@ func (s *testConsistentSuite) TestKeywordConsistent(c *C) {
 		c.Assert(k, Not(Equals), v)
 		c.Assert(tokenMap[k], Equals, tokenMap[v])
 	}
-	keywordCount := len(s.reservedKeywords) + len(s.unreservedKeywords) + len(s.notKeywordTokens) + len(s.tidbKeywords)
+	keywordCount := len(s.reservedKeywords) + len(s.unreservedKeywords) + len(s.notKeywordTokens) + len(s.tidbKeywords) + len(s.tidb4pgKeywords)
 	c.Assert(len(tokenMap)-len(aliases), Equals, keywordCount-len(windowFuncTokenMap))
 
 	unreservedCollectionDef := extractKeywordsFromCollectionDef(s.content, "\nUnReservedKeyword:")
@@ -72,6 +75,9 @@ func (s *testConsistentSuite) TestKeywordConsistent(c *C) {
 
 	tidbKeywordsCollectionDef := extractKeywordsFromCollectionDef(s.content, "\nTiDBKeyword:")
 	c.Assert(s.tidbKeywords, DeepEquals, tidbKeywordsCollectionDef)
+
+	tidb4pgKeywordsCollectionDef := extractKeywordsFromCollectionDef(s.content, "\nTiDB4PGKeyword::")
+	c.Assert(s.tidb4pgKeywords, DeepEquals, tidb4pgKeywordsCollectionDef)
 }
 
 func extractMiddle(str, startMarker, endMarker string) string {

--- a/misc.go
+++ b/misc.go
@@ -200,6 +200,7 @@ var tokenMap = map[string]int{
 	"CHANGE":                   change,
 	"CHAR":                     charType,
 	"CHARACTER":                character,
+	"CHARACTERISTICS":          characteristics,
 	"CHARSET":                  charsetKwd,
 	"CHECK":                    check,
 	"CHECKPOINT":               checkpoint,

--- a/parser.y
+++ b/parser.y
@@ -1245,6 +1245,7 @@ import (
 	NotKeywordToken                 "Tokens not mysql keyword but treated specially"
 	UnReservedKeyword               "MySQL unreserved keywords"
 	TiDBKeyword                     "TiDB added keywords"
+	TiDB4PGKeyword                  "TiDB for Postgres added keywords"
 	FunctionNameConflict            "Built-in function call names which are conflict with keywords"
 	FunctionNameOptionalBraces      "Function with optional braces, all of them are reserved keywords."
 	FunctionNameDatetimePrecision   "Function with optional datetime precision, all of them are reserved keywords."
@@ -4984,6 +4985,7 @@ Identifier:
 |	UnReservedKeyword
 |	NotKeywordToken
 |	TiDBKeyword
+|	TiDB4PGKeyword
 
 UnReservedKeyword:
 	"ACTION"
@@ -5382,6 +5384,9 @@ NotKeywordToken:
 |	"FLASHBACK"
 |	"JSON_OBJECTAGG"
 |	"TLS"
+
+TiDB4PGKeyword:
+	"CHARACTERISTICS"
 
 /************************************************************************************
  *

--- a/parser.y
+++ b/parser.y
@@ -705,6 +705,9 @@ import (
 	builtinVarPop
 	builtinVarSamp
 
+	/* The following tokens are added for TiDB for Postgres. */
+	characteristics "CHARACTERISTICS"
+
 %token	<item>
 
 	/*yy:token "1.%d"   */
@@ -8152,6 +8155,10 @@ SetStmt:
 |	"SET" "SESSION" "TRANSACTION" TransactionChars
 	{
 		$$ = &ast.SetStmt{Variables: $4.([]*ast.VariableAssignment)}
+	}
+|	"SET" "SESSION" "CHARACTERISTICS" "AS" "TRANSACTION" TransactionChars
+	{
+		$$ = &ast.SetStmt{Variables: $6.([]*ast.VariableAssignment)}
 	}
 |	"SET" "TRANSACTION" TransactionChars
 	{


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB SQL Parser! Please read 
[this](https://github.com/DigitalChinaOpenSource/DCParser/blob/master/README.md) or 
[this](https://github.com/DigitalChinaOpenSource/DCParser/blob/main/docs/quickstart.md)
document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Added support for pq syntax related to session characteristics, i.e.:
`SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ COMMITTED`

### What is changed and how it works?

In parser.y: 
added characteristic keyword
added a new identifier block for tidb4pg keywords

In unit test:
changed consistency unit tests for newly added tidb4pg keywords, `make test` should pass

