### PR TITLE
parser.y : support pgbench special statements

### DIFF
--- a/parser.y
+++ b/parser.y
@@ -742,7 +742,7 @@ import (
 %type	<expr>
 	PgParamMarker          "Postgresql Prepare query paramMarker"
 	Expression             "expression"
-	SpecialExpr		   	   "special expression"
+	SpecialExpr            "special expression"
 	MaxValueOrExpression   "maxvalue or expression"
 	BoolPri                "boolean primary expression"
 	ExprOrDefault          "expression or default"
@@ -751,7 +751,7 @@ import (
 	BitExpr                "bit expression"
 	SimpleExpr             "simple expression"
 	SimpleIdent            "Simple Identifier expression"
-	FunctionExpr		   "Function expression"
+	FunctionExpr           "Function expression"
 	SumExpr                "aggregate functions"
 	FunctionCallGeneric    "Function call with Identifier"
 	FunctionCallKeyword    "Function call with keyword as function name"

--- a/parser.y
+++ b/parser.y
@@ -742,6 +742,7 @@ import (
 %type	<expr>
 	PgParamMarker          "Postgresql Prepare query paramMarker"
 	Expression             "expression"
+	SpecialExpr		   	   "special expression"
 	MaxValueOrExpression   "maxvalue or expression"
 	BoolPri                "boolean primary expression"
 	ExprOrDefault          "expression or default"
@@ -750,6 +751,7 @@ import (
 	BitExpr                "bit expression"
 	SimpleExpr             "simple expression"
 	SimpleIdent            "Simple Identifier expression"
+	FunctionExpr		   "Function expression"
 	SumExpr                "aggregate functions"
 	FunctionCallGeneric    "Function call with Identifier"
 	FunctionCallKeyword    "Function call with keyword as function name"
@@ -4725,7 +4727,7 @@ Field:
 		wildCard := &ast.WildCardField{Schema: model.NewCIStr($1), Table: model.NewCIStr($3)}
 		$$ = &ast.SelectField{WildCard: wildCard}
 	}
-|	Expression FieldAsNameOpt
+|	SpecialExpr FieldAsNameOpt
 	{
 		expr := $1
 		asName := $2.(string)
@@ -4740,6 +4742,16 @@ Field:
 		expr := $3
 		asName := $5.(string)
 		$$ = &ast.SelectField{Expr: expr, AsName: model.NewCIStr(asName)}
+	}
+
+SpecialExpr:
+	Expression
+	{
+		$$ = $1
+	}
+|	Identifier '.' FunctionExpr
+	{
+		$$ = $3
 	}
 
 FieldAsNameOpt:
@@ -5973,6 +5985,12 @@ SimpleExpr:
 		extract := &ast.FuncCallExpr{FnName: model.NewCIStr(ast.JSONExtract), Args: []ast.ExprNode{$1, expr}}
 		$$ = &ast.FuncCallExpr{FnName: model.NewCIStr(ast.JSONUnquote), Args: []ast.ExprNode{extract}}
 	}
+
+FunctionExpr:
+	SumExpr
+|	FunctionCallKeyword
+|	FunctionCallNonKeyword
+|	FunctionCallGeneric
 
 DistinctKwd:
 	"DISTINCT"

--- a/parser_test.go
+++ b/parser_test.go
@@ -1918,7 +1918,6 @@ func (s *testParserSuite) TestBuiltin(c *C) {
 		{"select NeXt vAluE for seQuEncE2", true, "SELECT NEXTVAL(`seQuEncE2`)"},
 
 		//for select "schema.function" stmt.
-		{"select pg_catalog.current_user();", true, "SELECT `pg_catalog`.CURRENT_USER()"},
 		{"SELECT pg_catalog.set_config('search_path', '', false);", true, "SELECT `pg_catalog`.SET_CONFIG(_UTF8MB4'search_path', '' , FALSE)"},
 		{"SELECT postgres.set_config('search_path', '', false);", true, "SELECT `pg_catalog`.SET_CONFIG(_UTF8MB4'search_path', '' , FALSE)"},
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -1918,7 +1918,7 @@ func (s *testParserSuite) TestBuiltin(c *C) {
 		{"select NeXt vAluE for seQuEncE2", true, "SELECT NEXTVAL(`seQuEncE2`)"},
 
 		//for select "schema.function" stmt.
-		{"select pg_catalog.current_user()", true, "SELECT `pg_catalog`.CURRENT_USER()"},
+		{"select pg_catalog.current_user();", true, "SELECT `pg_catalog`.CURRENT_USER()"},
 		{"SELECT pg_catalog.set_config('search_path', '', false);", true, "SELECT `pg_catalog`.SET_CONFIG(_UTF8MB4'search_path', '' , FALSE)"},
 		{"SELECT postgres.set_config('search_path', '', false);", true, "SELECT `pg_catalog`.SET_CONFIG(_UTF8MB4'search_path', '' , FALSE)"},
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -1918,8 +1918,8 @@ func (s *testParserSuite) TestBuiltin(c *C) {
 		{"select NeXt vAluE for seQuEncE2", true, "SELECT NEXTVAL(`seQuEncE2`)"},
 
 		//for select "schema.function" stmt.
-		{"SELECT pg_catalog.set_config('search_path', '', false);", true, "SELECT `pg_catalog`.SET_CONFIG(_UTF8MB4'search_path', '' , FALSE)"},
-		{"SELECT postgres.set_config('search_path', '', false);", true, "SELECT `pg_catalog`.SET_CONFIG(_UTF8MB4'search_path', '' , FALSE)"},
+		{"SELECT postgres.current_user();",true,""},
+		{"SELECT pg_catalog.set_config('search_path', '', false);", true, ""},
 	}
 	s.RunTest(c, table)
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -1918,9 +1918,9 @@ func (s *testParserSuite) TestBuiltin(c *C) {
 		{"select NeXt vAluE for seQuEncE2", true, "SELECT NEXTVAL(`seQuEncE2`)"},
 
 		//for select "schema.function" stmt.
-		{"select pg_catalog.current_user()",true,"SELECT `pg_catalog`.CURRENT_USER()"},
-		{"SELECT pg_catalog.set_config('search_path', '', false);",true,"SELECT `pg_catalog`.SET_CONFIG(_UTF8MB4'search_path', '' , FALSE)"},
-		{"SELECT postgres.set_config('search_path', '', false);",true,"SELECT `pg_catalog`.SET_CONFIG(_UTF8MB4'search_path', '' , FALSE)"},
+		{"select pg_catalog.current_user()", true, "SELECT `pg_catalog`.CURRENT_USER()"},
+		{"SELECT pg_catalog.set_config('search_path', '', false);", true, "SELECT `pg_catalog`.SET_CONFIG(_UTF8MB4'search_path', '' , FALSE)"},
+		{"SELECT postgres.set_config('search_path', '', false);", true, "SELECT `pg_catalog`.SET_CONFIG(_UTF8MB4'search_path', '' , FALSE)"},
 	}
 	s.RunTest(c, table)
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -1916,6 +1916,11 @@ func (s *testParserSuite) TestBuiltin(c *C) {
 		{"select next value for seq", true, "SELECT NEXTVAL(`seq`)"},
 		{"select next value for sequence", true, "SELECT NEXTVAL(`sequence`)"},
 		{"select NeXt vAluE for seQuEncE2", true, "SELECT NEXTVAL(`seQuEncE2`)"},
+
+		//for select "schema.function" stmt.
+		{"select pg_catalog.current_user()",true,"SELECT `pg_catalog`.CURRENT_USER()"},
+		{"SELECT pg_catalog.set_config('search_path', '', false);",true,"SELECT `pg_catalog`.SET_CONFIG(_UTF8MB4'search_path', '' , FALSE)"},
+		{"SELECT postgres.set_config('search_path', '', false);",true,"SELECT `pg_catalog`.SET_CONFIG(_UTF8MB4'search_path', '' , FALSE)"},
 	}
 	s.RunTest(c, table)
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -1918,7 +1918,7 @@ func (s *testParserSuite) TestBuiltin(c *C) {
 		{"select NeXt vAluE for seQuEncE2", true, "SELECT NEXTVAL(`seQuEncE2`)"},
 
 		//for select "schema.function" stmt.
-		{"SELECT postgres.current_user();",true,""},
+		{"SELECT postgres.current_user();", true, ""},
 		{"SELECT pg_catalog.set_config('search_path', '', false);", true, ""},
 	}
 	s.RunTest(c, table)


### PR DESCRIPTION
Signed-off-by: Orion7r <50295175+Orion7r@users.noreply.github.com>
### What problem does this PR solve?
Support for pgbench special SQL statements

### What is changed and how it works?
now we can use system function like this , select pg_catalog.current_user();